### PR TITLE
Image enhancements

### DIFF
--- a/Rasterizer/BWImage.cs
+++ b/Rasterizer/BWImage.cs
@@ -14,12 +14,12 @@ namespace Rasterizer
 
 		public override int GetValue(int x, int y)
 		{
-			return data[x * size.Width + y] ? 0 : 255;
+			return data[x * size.Height + y] ? 0 : 255;
 		}
 
 		public override void SetValue(int x, int y, int value)
 		{
-			data[x * size.Width + y] = value < 128;
+			data[x * size.Height + y] = value < 128;
 		}
 	}
 }

--- a/Rasterizer/BWImage.cs
+++ b/Rasterizer/BWImage.cs
@@ -10,7 +10,7 @@ namespace Rasterizer
 		public BWImage(Size size, bool[] data) : base(size, data){}
 		public BWImage(Size size) : base(size){}
 		public BWImage(MonochromeImage<bool> other) : base(other){}
-		public BWImage(Bitmap image) : base(image){}
+		public BWImage(Bitmap image, bool visualSpace = true) : base(image, visualSpace){}
 
 		public override int GetValue(int x, int y)
 		{

--- a/Rasterizer/BWImage.cs
+++ b/Rasterizer/BWImage.cs
@@ -1,3 +1,5 @@
+using System.Drawing;
+
 namespace Rasterizer
 {
 	/// <summary>
@@ -5,12 +7,17 @@ namespace Rasterizer
 	/// </summary>
 	public class BWImage : MonochromeImage<bool>
 	{
-		public int GetValue(int x, int y)
+		public BWImage(Size size, bool[] data) : base(size, data){}
+		public BWImage(Size size) : base(size){}
+		public BWImage(MonochromeImage<bool> other) : base(other){}
+		public BWImage(Bitmap image) : base(image){}
+
+		public override int GetValue(int x, int y)
 		{
 			return data[x * size.Width + y] ? 0 : 255;
 		}
 
-		public void SetValue(int x, int y, int value)
+		public override void SetValue(int x, int y, int value)
 		{
 			data[x * size.Width + y] = value < 128;
 		}

--- a/Rasterizer/BWImage.cs
+++ b/Rasterizer/BWImage.cs
@@ -1,49 +1,18 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Drawing;
-using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
-
 namespace Rasterizer
 {
 	/// <summary>
-	/// A halftone image represented by a boolean matrix (true/false is black/white, resp.)
+	/// A halftone image represented by a boolean matrix (true is black, false is white)
 	/// </summary>
-	public class BWImage
+	public class BWImage : MonochromeImage<bool>
 	{
-		public Size size;
-		public bool[] data;
-
-		public BWImage(Size size, bool[] data)
+		public int GetValue(int x, int y)
 		{
-			this.size = size;
-			this.data = data;
+			return data[x * size.Width + y] ? 0 : 255;
 		}
 
-		public BWImage(Size size)
+		public void SetValue(int x, int y, int value)
 		{
-			this.size = size;
-			data = new bool[size.Width * size.Height];
-		}
-
-		/// <summary>
-		/// Bitmap rendering of the image; true -> #000, false -> #fff
-		/// </summary>
-		/// <returns></returns>
-		public Bitmap GetBitmap()
-		{
-			var output = new Bitmap(size.Width, size.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-			for(int y = 0; y < size.Height; y++)
-			{
-				for(int x = 0; x < size.Width; x++)
-				{
-					int value = data[x + size.Width * y] ? 0 : 255;
-					Color c = Color.FromArgb(value, value, value);
-					output.SetPixel(x, y, c);
-				}
-			}
-			return output;
+			data[x * size.Width + y] = value < 128;
 		}
 	}
 }

--- a/Rasterizer/Ditherer.cs
+++ b/Rasterizer/Ditherer.cs
@@ -50,14 +50,21 @@ namespace Rasterizer
 		{
 			size = image.size;
 			size.Width = (size.Width / 8) * 8;
-			GrayscaleImage workspace = new GrayscaleImage(image);
 			BWImage output = new BWImage(size);
+			var data = new byte[size.Width, size.Height];
+			for(int y = 0; y < size.Height; y++)
+			{
+				for(int x = 0; x < size.Width; x++)
+				{
+					data[x, y] = (byte)image.GetValue(x, y);
+				}
+			}
 
 			for(int y = 0; y < size.Height; y++)
 			{
 				for(int x = 0; x < size.Width; x++)
 				{
-					int value = workspace.GetValue(x, y);
+					byte value = data[x, y];
 					bool thresholded = value < threshold;
 					int error = thresholded ? value : value - 255;
 
@@ -70,8 +77,7 @@ namespace Rasterizer
 							int newy = y + shifty;
 							if(newy < size.Height)
 							{
-								int newValue = workspace.GetValue(x, y) + ((BurkesDistribution[shiftx + 5 * shifty] * error) >> 5);
-								workspace.SetValue(newx, newy, newValue);
+								data[newx, newy] = ClipToByte(data[newx, newy] + ((BurkesDistribution[shiftx + 5 * shifty] * error) >> 5));
 							}
 						}
 
@@ -82,7 +88,7 @@ namespace Rasterizer
 						}
 					}
 
-					output.data[x + size.Width * y] = thresholded;
+					output.data[x * size.Height + y] = thresholded;
 				}
 			}
 			return output;

--- a/Rasterizer/Ditherer.cs
+++ b/Rasterizer/Ditherer.cs
@@ -25,7 +25,6 @@ namespace Rasterizer
 	{
 		public byte threshold;
 		private Size size;
-		private byte[,] data;
 
 		public BurkesDitherer(byte threshold = 96)
 		{
@@ -49,7 +48,7 @@ namespace Rasterizer
 
 		public BWImage GetBWImage(GrayscaleImage image)
 		{
-			size = image.Size;
+			size = image.size;
 			size.Width = (size.Width / 8) * 8;
 			GrayscaleImage workspace = new GrayscaleImage(image);
 			BWImage output = new BWImage(size);

--- a/Rasterizer/Enhancer.cs
+++ b/Rasterizer/Enhancer.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Drawing;
+using System.Collections.Generic;
 
 
 namespace Rasterizer
@@ -43,6 +44,31 @@ namespace Rasterizer
     private float Lerp(float a, float b, float t)
     {
       return a * (1f - t) + b * t;
+    }
+  }
+
+  public class QuantileEnhancer : IEnhancer
+  {
+    public GrayscaleImage Enhance(GrayscaleImage image)
+    {
+      var pixelValues = new List<float>(image.data);
+      pixelValues.Sort();
+      float[] mapping = new float[256];
+      for (int i = 0; i < pixelValues.Count; i++)
+      {
+        mapping[(int)pixelValue[i]] = (int)(i * 255f / pixelValues.Count);
+      }
+
+      GrayscaleImage result = new GrayscaleImage(image.size);
+      for (int x = 0; x < result.size.Width; x++)
+      {
+        for (int y = 0; y < result.size.Height; y++)
+        {
+          var newValue = mapping[(int)image.GetValue(x, y)];
+          result.SetValue(x, y, newValue);
+        }
+      }
+      return result;
     }
   }
 }

--- a/Rasterizer/Enhancer.cs
+++ b/Rasterizer/Enhancer.cs
@@ -35,15 +35,10 @@ namespace Rasterizer
 			{
 				for (int y = 0; y < image.size.Height; y++)
 				{
-					result.SetValue(x, y, Lerp(image.GetValue(x, y), blurred.GetValue(x, y), -this.factor));
+					result.SetValue(x, y, image.GetValue(x, y) - blurred.GetValue(x, y) * this.factor);
 				}
 			}
 			return result;
-		}
-
-		private float Lerp(float a, float b, float t)
-		{
-			return a * (1f - t) + b * t;
 		}
 	}
 
@@ -56,7 +51,7 @@ namespace Rasterizer
 			float[] mapping = new float[256];
 			for (int i = 0; i < pixelValues.Count; i++)
 			{
-				mapping[(int)pixelValues[i]] = (int)(i * 255f / pixelValues.Count);
+				mapping[(int)Math.Clamp(pixelValues[i], 0, 255)] = (int)(i * 255.5f / pixelValues.Count);
 			}
 
 			GrayscaleImage result = new GrayscaleImage(image.size);

--- a/Rasterizer/Enhancer.cs
+++ b/Rasterizer/Enhancer.cs
@@ -1,0 +1,48 @@
+using System;
+using System.Drawing;
+
+
+namespace Rasterizer
+{
+  public interface IEnhancer
+  {
+    /// <summary>
+		/// Apply an image enhancement algorithm on a grayscale image.
+		/// </summary>
+		/// <param name="image"></param>
+		/// <returns></returns>
+		GrayscaleImage Enhance(GrayscaleImage image);
+  }
+
+  public class HDREnhancer : IEnhancer
+  {
+    public readonly float factor;
+    public readonly float numSegments;
+
+    public HDREnhancer(float factor, float numSegments=4)
+    {
+      this.factor = factor;
+      this.numSegments = numSegments;
+    }
+
+    public GrayscaleImage Enhance(GrayscaleImage image)
+    {
+      float blurFactor = Math.Min(image.size.Width, image.size.Height) / this.numSegments;
+      var blurred = image.Blurred(blurFactor);
+      var result = new GrayscaleImage(image.size);
+      for (int x = 0; x < image.size.Width; x++)
+      {
+        for (int y = 0; y < image.size.Height; y++)
+        {
+          result.SetValue(x, y, Lerp(image.GetValue(x, y), blurred.GetValue(x, y), -this.factor));
+        }
+      }
+      return result;
+    }
+
+    private float Lerp(float a, float b, float t)
+    {
+      return a * (1f - t) + b * t;
+    }
+  }
+}

--- a/Rasterizer/Enhancer.cs
+++ b/Rasterizer/Enhancer.cs
@@ -35,10 +35,15 @@ namespace Rasterizer
 			{
 				for (int y = 0; y < image.size.Height; y++)
 				{
-					result.SetValue(x, y, image.GetValue(x, y) - blurred.GetValue(x, y) * this.factor);
+					result.SetValue(x, y, EnhancePixel(image.GetValue(x, y), blurred.GetValue(x, y)));
 				}
 			}
 			return result;
+		}
+
+		private float EnhancePixel(float sharp, float blurred)
+		{
+			return sharp + (127 - blurred) * factor;
 		}
 	}
 

--- a/Rasterizer/Enhancer.cs
+++ b/Rasterizer/Enhancer.cs
@@ -56,7 +56,7 @@ namespace Rasterizer
 			float[] mapping = new float[256];
 			for (int i = 0; i < pixelValues.Count; i++)
 			{
-				mapping[(int)pixelValue[i]] = (int)(i * 255f / pixelValues.Count);
+				mapping[(int)pixelValues[i]] = (int)(i * 255f / pixelValues.Count);
 			}
 
 			GrayscaleImage result = new GrayscaleImage(image.size);

--- a/Rasterizer/Enhancer.cs
+++ b/Rasterizer/Enhancer.cs
@@ -15,14 +15,42 @@ namespace Rasterizer
 		GrayscaleImage Enhance(GrayscaleImage image);
 	}
 
-	public class HDREnhancer : IEnhancer
+	public class HDREnhancer : BlurBasedEnhancer
 	{
 		public readonly float factor;
-		public readonly float numSegments;
 
-		public HDREnhancer(float factor, float numSegments=4)
+		public HDREnhancer(float factor, float numSegments = 4) : base(numSegments)
 		{
 			this.factor = factor;
+		}
+
+		protected override float EnhancePixel(float sharp, float blurred)
+		{
+			return sharp + (127 - blurred) * factor;
+		}
+	}
+
+	public class ContrastEnhancer : BlurBasedEnhancer
+	{
+		public readonly float factor;
+
+		public ContrastEnhancer(float factor, float numSegments = 4) : base(numSegments)
+		{
+			this.factor = factor;
+		}
+
+		protected override float EnhancePixel(float sharp, float blurred)
+		{
+			return sharp * (1f + factor) - blurred * factor;
+		}
+	}
+
+	public abstract class BlurBasedEnhancer : IEnhancer
+	{
+		public readonly float numSegments;
+
+		public BlurBasedEnhancer(float numSegments=4)
+		{
 			this.numSegments = numSegments;
 		}
 
@@ -41,10 +69,7 @@ namespace Rasterizer
 			return result;
 		}
 
-		private float EnhancePixel(float sharp, float blurred)
-		{
-			return sharp + (127 - blurred) * factor;
-		}
+		protected abstract float EnhancePixel(float sharp, float blurred);
 	}
 
 	public class QuantileEnhancer : IEnhancer

--- a/Rasterizer/Enhancer.cs
+++ b/Rasterizer/Enhancer.cs
@@ -5,70 +5,70 @@ using System.Collections.Generic;
 
 namespace Rasterizer
 {
-  public interface IEnhancer
-  {
-    /// <summary>
+	public interface IEnhancer
+	{
+		/// <summary>
 		/// Apply an image enhancement algorithm on a grayscale image.
 		/// </summary>
 		/// <param name="image"></param>
 		/// <returns></returns>
 		GrayscaleImage Enhance(GrayscaleImage image);
-  }
+	}
 
-  public class HDREnhancer : IEnhancer
-  {
-    public readonly float factor;
-    public readonly float numSegments;
+	public class HDREnhancer : IEnhancer
+	{
+		public readonly float factor;
+		public readonly float numSegments;
 
-    public HDREnhancer(float factor, float numSegments=4)
-    {
-      this.factor = factor;
-      this.numSegments = numSegments;
-    }
+		public HDREnhancer(float factor, float numSegments=4)
+		{
+			this.factor = factor;
+			this.numSegments = numSegments;
+		}
 
-    public GrayscaleImage Enhance(GrayscaleImage image)
-    {
-      float blurFactor = Math.Min(image.size.Width, image.size.Height) / this.numSegments;
-      var blurred = image.Blurred(blurFactor);
-      var result = new GrayscaleImage(image.size);
-      for (int x = 0; x < image.size.Width; x++)
-      {
-        for (int y = 0; y < image.size.Height; y++)
-        {
-          result.SetValue(x, y, Lerp(image.GetValue(x, y), blurred.GetValue(x, y), -this.factor));
-        }
-      }
-      return result;
-    }
+		public GrayscaleImage Enhance(GrayscaleImage image)
+		{
+			float blurFactor = Math.Min(image.size.Width, image.size.Height) / this.numSegments;
+			var blurred = image.Blurred(blurFactor);
+			var result = new GrayscaleImage(image.size);
+			for (int x = 0; x < image.size.Width; x++)
+			{
+				for (int y = 0; y < image.size.Height; y++)
+				{
+					result.SetValue(x, y, Lerp(image.GetValue(x, y), blurred.GetValue(x, y), -this.factor));
+				}
+			}
+			return result;
+		}
 
-    private float Lerp(float a, float b, float t)
-    {
-      return a * (1f - t) + b * t;
-    }
-  }
+		private float Lerp(float a, float b, float t)
+		{
+			return a * (1f - t) + b * t;
+		}
+	}
 
-  public class QuantileEnhancer : IEnhancer
-  {
-    public GrayscaleImage Enhance(GrayscaleImage image)
-    {
-      var pixelValues = new List<float>(image.data);
-      pixelValues.Sort();
-      float[] mapping = new float[256];
-      for (int i = 0; i < pixelValues.Count; i++)
-      {
-        mapping[(int)pixelValue[i]] = (int)(i * 255f / pixelValues.Count);
-      }
+	public class QuantileEnhancer : IEnhancer
+	{
+		public GrayscaleImage Enhance(GrayscaleImage image)
+		{
+			var pixelValues = new List<float>(image.data);
+			pixelValues.Sort();
+			float[] mapping = new float[256];
+			for (int i = 0; i < pixelValues.Count; i++)
+			{
+				mapping[(int)pixelValue[i]] = (int)(i * 255f / pixelValues.Count);
+			}
 
-      GrayscaleImage result = new GrayscaleImage(image.size);
-      for (int x = 0; x < result.size.Width; x++)
-      {
-        for (int y = 0; y < result.size.Height; y++)
-        {
-          var newValue = mapping[(int)image.GetValue(x, y)];
-          result.SetValue(x, y, newValue);
-        }
-      }
-      return result;
-    }
-  }
+			GrayscaleImage result = new GrayscaleImage(image.size);
+			for (int x = 0; x < result.size.Width; x++)
+			{
+				for (int y = 0; y < result.size.Height; y++)
+				{
+					var newValue = mapping[(int)image.GetValue(x, y)];
+					result.SetValue(x, y, newValue);
+				}
+			}
+			return result;
+		}
+	}
 }

--- a/Rasterizer/Enhancer.cs
+++ b/Rasterizer/Enhancer.cs
@@ -74,6 +74,13 @@ namespace Rasterizer
 
 	public class QuantileEnhancer : IEnhancer
 	{
+		public readonly float factor;
+
+		public QuantileEnhancer(float factor)
+		{
+			this.factor = factor;
+		}
+
 		public GrayscaleImage Enhance(GrayscaleImage image)
 		{
 			var pixelValues = new List<float>(image.data);
@@ -89,7 +96,8 @@ namespace Rasterizer
 			{
 				for (int y = 0; y < result.size.Height; y++)
 				{
-					var newValue = mapping[(int)image.GetValue(x, y)];
+					var mappedValue = mapping[(int)image.GetValue(x, y)];
+					var newValue = image.GetValue(x, y) * (1f - factor) + mappedValue * factor;
 					result.SetValue(x, y, newValue);
 				}
 			}

--- a/Rasterizer/GrayscaleImage.cs
+++ b/Rasterizer/GrayscaleImage.cs
@@ -1,0 +1,23 @@
+namespace Rasterizer
+{
+	/// <summary>
+	/// A grayscale image represented by a floating-point matrix (0 is black, 255 is white)
+	/// </summary>
+	public class GrayscaleImage : MonochromeImage<float>
+	{
+		public int GetValue(int x, int y)
+		{
+			return Math.Clamp((int)data[x * size.Width + y], 0, 255);
+		}
+
+		public void SetValue(int x, int y, int value)
+		{
+			data[x * size.Width + y] = value;
+		}
+
+		public void SetValue(int x, int y, float value)
+		{
+			data[x * size.Width + y] = value;
+		}
+	}
+}

--- a/Rasterizer/GrayscaleImage.cs
+++ b/Rasterizer/GrayscaleImage.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Drawing;
+
 namespace Rasterizer
 {
 	/// <summary>
@@ -5,19 +8,41 @@ namespace Rasterizer
 	/// </summary>
 	public class GrayscaleImage : MonochromeImage<float>
 	{
-		public int GetValue(int x, int y)
+		public GrayscaleImage(Size size, float[] data) : base(size, data){}
+		public GrayscaleImage(Size size) : base(size){}
+		public GrayscaleImage(MonochromeImage<float> other) : base(other){}
+		public GrayscaleImage(Bitmap image) : base(image){}
+
+		public override int GetValue(int x, int y)
 		{
 			return Math.Clamp((int)data[x * size.Width + y], 0, 255);
 		}
 
-		public void SetValue(int x, int y, int value)
+		public override void SetValue(int x, int y, int value)
 		{
 			data[x * size.Width + y] = value;
 		}
 
-		public void SetValue(int x, int y, float value)
+		public override void SetValue(int x, int y, float value)
 		{
 			data[x * size.Width + y] = value;
+		}
+
+		public GrayscaleImage Blurred(float factor)
+		{
+			var smaller = ResizeBitmap(GetBitmap(), (int)(size.Width / factor), (int)(size.Height / factor));
+			var blurred = ResizeBitmap(smaller, size.Width, size.Height);
+			return new GrayscaleImage(blurred);
+		}
+
+		private static Bitmap ResizeBitmap(Bitmap bmp, int width, int height)
+		{
+			var result = new Bitmap(width, height);
+			using (Graphics g = Graphics.FromImage(result))
+			{
+				g.DrawImage(bmp, 0, 0, width, height);
+			}
+			return result;
 		}
 	}
 }

--- a/Rasterizer/GrayscaleImage.cs
+++ b/Rasterizer/GrayscaleImage.cs
@@ -11,7 +11,7 @@ namespace Rasterizer
 		public GrayscaleImage(Size size, float[] data) : base(size, data){}
 		public GrayscaleImage(Size size) : base(size){}
 		public GrayscaleImage(MonochromeImage<float> other) : base(other){}
-		public GrayscaleImage(Bitmap image) : base(image){}
+		public GrayscaleImage(Bitmap image, bool visualSpace = true) : base(image, visualSpace){}
 
 		public override int GetValue(int x, int y)
 		{
@@ -30,9 +30,9 @@ namespace Rasterizer
 
 		public GrayscaleImage Blurred(float factor)
 		{
-			var smaller = ResizeBitmap(GetBitmap(), (int)(size.Width / factor), (int)(size.Height / factor));
+			var smaller = ResizeBitmap(GetBitmap(false), (int)(size.Width / factor), (int)(size.Height / factor));
 			var blurred = ResizeBitmap(smaller, size.Width, size.Height);
-			return new GrayscaleImage(blurred);
+			return new GrayscaleImage(blurred, false);
 		}
 
 		private static Bitmap ResizeBitmap(Bitmap bmp, int width, int height)

--- a/Rasterizer/GrayscaleImage.cs
+++ b/Rasterizer/GrayscaleImage.cs
@@ -15,17 +15,17 @@ namespace Rasterizer
 
 		public override int GetValue(int x, int y)
 		{
-			return Math.Clamp((int)data[x * size.Width + y], 0, 255);
+			return Math.Clamp((int)data[x * size.Height + y], 0, 255);
 		}
 
 		public override void SetValue(int x, int y, int value)
 		{
-			data[x * size.Width + y] = value;
+			data[x * size.Height + y] = value;
 		}
 
 		public override void SetValue(int x, int y, float value)
 		{
-			data[x * size.Width + y] = value;
+			data[x * size.Height + y] = value;
 		}
 
 		public GrayscaleImage Blurred(float factor)

--- a/Rasterizer/MonochromeImage.cs
+++ b/Rasterizer/MonochromeImage.cs
@@ -36,7 +36,7 @@ namespace Rasterizer
 			}
 		}
 
-		public MonochromeImage(Bitmap image)
+		public MonochromeImage(Bitmap image, bool visualSpace = true)
 		{
 			this.size = image.Size;
 			this.data = new T[size.Width * size.Height];
@@ -44,6 +44,8 @@ namespace Rasterizer
 			{
 				for(int y = 0; y < size.Height; y++)
 				{
+					Color color = image.GetPixel(x, y);
+					float gray = visualSpace ? ColorToGray(color) : (color.R + color.G + color.B) / 3;
 					this.SetValue(x, y, ColorToGray(image.GetPixel(x, y)));
 				}
 			}
@@ -53,14 +55,16 @@ namespace Rasterizer
 		/// Bitmap rendering of the image
 		/// </summary>
 		/// <returns></returns>
-		public Bitmap GetBitmap()
+		public Bitmap GetBitmap(bool visualSpace = true)
 		{
 			var output = new Bitmap(size.Width, size.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
 			for(int x = 0; x < size.Width; x++)
 			{
 				for(int y = 0; y < size.Height; y++)
 				{
-					output.SetPixel(x, y, ColorFromGray(GetValue(x, y)));
+					int gray = GetValue(x, y);
+					Color color = visualSpace ? ColorFromGray(gray) : Color.FromArgb(gray, gray, gray);
+					output.SetPixel(x, y, color);
 				}
 			}
 			return output;
@@ -81,7 +85,7 @@ namespace Rasterizer
 			return (1f - invValue * invValue) * 255;
 		}
 
-		private static Color ColorFromGray(float gray)
+		private static Color ColorFromGray(int gray)
 		{
 			var invValue = Math.Sqrt(1f - gray / 255f);
 			int value = (int)((1f - invValue) * 255f);

--- a/Rasterizer/MonochromeImage.cs
+++ b/Rasterizer/MonochromeImage.cs
@@ -1,0 +1,96 @@
+using System.Drawing;
+
+namespace Rasterizer
+{
+	/// <summary>
+	/// A grayscale image represented by a matrix
+	/// </summary>
+	public abstract class MonochromeImage<T> where T : new()
+	{
+		public Size size;
+		public T[] data;
+
+		public MonochromeImage(Size size, T[] data)
+		{
+			this.size = size;
+			this.data = data;
+		}
+
+		public MonochromeImage(Size size)
+		{
+			this.size = size;
+			this.data = new T[size.Width * size.Height];
+		}
+
+    public MonochromeImage(MonochromeImage<T> other)
+    {
+      this.size = other.size;
+			this.data = new T[size.Width * size.Height];
+      for (int x = 0; x < this.size.Width; x++)
+      {
+        for (int y = 0; y < this.size.Height; y++)
+        {
+          this.data[x * this.size.Width + y] = other.data[x * this.size.Width + y];
+        }
+      }
+    }
+
+    public MonochromeImage(Bitmap image)
+    {
+      this.size = new Size(bmp.Size);
+      for(int y = 0; y < this.size.Height; y++)
+			{
+				for(int x = 0; x < this.size.Width; x++)
+				{
+          Color c = image.GetPixel(x, y);
+					float pixelValue = (c.R * 2126 + c.G * 7152 + c.B * 0722)/2550000f;
+					float invValue = 1f - pixelValue;
+					this.SetValue(x, y, (1f - invValue * invValue) * 255);
+				}
+			}
+    }
+
+		/// <summary>
+		/// Bitmap rendering of the image
+		/// </summary>
+		/// <returns></returns>
+		public Bitmap GetBitmap()
+		{
+			var output = new Bitmap(size.Width, size.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+			for(int y = 0; y < size.Height; y++)
+			{
+				for(int x = 0; x < size.Width; x++)
+				{
+					int value = (int)Math.Sqrt(1f - GetValue(x, y) / 255f);
+					Color c = Color.FromArgb(value, value, value);
+					output.SetPixel(x, y, c);
+				}
+			}
+			return output;
+		}
+
+    public abstract int GetValue(int x, int y);
+    public abstract void SetValue(int x, int y, int value);
+
+		public void SetValue(int x, int y, float value)
+		{
+			SetValue(x, y, (int)value);
+		}
+
+		public MonochromeImage<T> Blurred(float factor)
+		{
+			var smaller = ResizeBitmap(GetBitmap(), (int)(size.Width / factor), (int)(size.Height / factor));
+			var blurred = ResizeBitmap(smaller, size.Width, size.Height);
+			return new MonochromeImage<T>(blurred);
+		}
+
+		private static Bitmap ResizeBitmap(Bitmap bmp, int width, int height)
+		{
+			var result = new Bitmap(width, height);
+			using (Graphics g = Graphics.FromImage(result))
+			{
+				g.DrawImage(bmp, 0, 0, width, height);
+			}
+			return result;
+	}
+}

--- a/Rasterizer/MonochromeImage.cs
+++ b/Rasterizer/MonochromeImage.cs
@@ -22,33 +22,33 @@ namespace Rasterizer
 			this.data = new T[size.Width * size.Height];
 		}
 
-    public MonochromeImage(MonochromeImage<T> other)
-    {
-      this.size = other.size;
+		public MonochromeImage(MonochromeImage<T> other)
+		{
+			this.size = other.size;
 			this.data = new T[size.Width * size.Height];
-      for (int x = 0; x < this.size.Width; x++)
-      {
-        for (int y = 0; y < this.size.Height; y++)
-        {
-          this.data[x * this.size.Width + y] = other.data[x * this.size.Width + y];
-        }
-      }
-    }
+			for (int x = 0; x < this.size.Width; x++)
+			{
+				for (int y = 0; y < this.size.Height; y++)
+				{
+					this.data[x * this.size.Width + y] = other.data[x * this.size.Width + y];
+				}
+			}
+		}
 
-    public MonochromeImage(Bitmap image)
-    {
-      this.size = new Size(bmp.Size);
-      for(int y = 0; y < this.size.Height; y++)
+		public MonochromeImage(Bitmap image)
+		{
+			this.size = new Size(bmp.Size);
+			for(int y = 0; y < this.size.Height; y++)
 			{
 				for(int x = 0; x < this.size.Width; x++)
 				{
-          Color c = image.GetPixel(x, y);
+					Color c = image.GetPixel(x, y);
 					float pixelValue = (c.R * 2126 + c.G * 7152 + c.B * 0722)/2550000f;
 					float invValue = 1f - pixelValue;
 					this.SetValue(x, y, (1f - invValue * invValue) * 255);
 				}
 			}
-    }
+		}
 
 		/// <summary>
 		/// Bitmap rendering of the image
@@ -69,8 +69,8 @@ namespace Rasterizer
 			return output;
 		}
 
-    public abstract int GetValue(int x, int y);
-    public abstract void SetValue(int x, int y, int value);
+		public abstract int GetValue(int x, int y);
+		public abstract void SetValue(int x, int y, int value);
 
 		public void SetValue(int x, int y, float value)
 		{

--- a/Rasterizer/MonochromeImage.cs
+++ b/Rasterizer/MonochromeImage.cs
@@ -40,14 +40,11 @@ namespace Rasterizer
 		{
 			this.size = image.Size;
 			this.data = new T[size.Width * size.Height];
-			for(int y = 0; y < this.size.Height; y++)
+			for(int x = 0; x < size.Width; x++)
 			{
-				for(int x = 0; x < this.size.Width; x++)
+				for(int y = 0; y < size.Height; y++)
 				{
-					Color c = image.GetPixel(x, y);
-					float pixelValue = (c.R * 2126 + c.G * 7152 + c.B * 0722)/2550000f;
-					float invValue = 1f - pixelValue;
-					this.SetValue(x, y, (1f - invValue * invValue) * 255);
+					this.SetValue(x, y, ColorToGray(image.GetPixel(x, y)));
 				}
 			}
 		}
@@ -59,13 +56,11 @@ namespace Rasterizer
 		public Bitmap GetBitmap()
 		{
 			var output = new Bitmap(size.Width, size.Height, System.Drawing.Imaging.PixelFormat.Format32bppArgb);
-			for(int y = 0; y < size.Height; y++)
+			for(int x = 0; x < size.Width; x++)
 			{
-				for(int x = 0; x < size.Width; x++)
+				for(int y = 0; y < size.Height; y++)
 				{
-					int value = (int)(Math.Sqrt(1f - GetValue(x, y) / 255f) * 255f);
-					Color c = Color.FromArgb(value, value, value);
-					output.SetPixel(x, y, c);
+					output.SetPixel(x, y, ColorFromGray(GetValue(x, y)));
 				}
 			}
 			return output;
@@ -77,6 +72,20 @@ namespace Rasterizer
 		public virtual void SetValue(int x, int y, float value)
 		{
 			SetValue(x, y, (int)value);
+		}
+
+		private static float ColorToGray(Color color)
+		{
+			float pixelValue = (color.R * 2126 + color.G * 7152 + color.B * 0722)/2550000f;
+			float invValue = 1f - pixelValue;
+			return (1f - invValue * invValue) * 255;
+		}
+
+		private static Color ColorFromGray(float gray)
+		{
+			var invValue = Math.Sqrt(1f - gray / 255f);
+			int value = (int)((1f - invValue) * 255f);
+			return Color.FromArgb(value, value, value);
 		}
 	}
 }

--- a/Rasterizer/MonochromeImage.cs
+++ b/Rasterizer/MonochromeImage.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Drawing;
 
 namespace Rasterizer
@@ -37,7 +38,8 @@ namespace Rasterizer
 
 		public MonochromeImage(Bitmap image)
 		{
-			this.size = new Size(bmp.Size);
+			this.size = image.Size;
+			this.data = new T[size.Width * size.Height];
 			for(int y = 0; y < this.size.Height; y++)
 			{
 				for(int x = 0; x < this.size.Width; x++)
@@ -61,7 +63,7 @@ namespace Rasterizer
 			{
 				for(int x = 0; x < size.Width; x++)
 				{
-					int value = (int)Math.Sqrt(1f - GetValue(x, y) / 255f);
+					int value = (int)(Math.Sqrt(1f - GetValue(x, y) / 255f) * 255f);
 					Color c = Color.FromArgb(value, value, value);
 					output.SetPixel(x, y, c);
 				}
@@ -72,25 +74,9 @@ namespace Rasterizer
 		public abstract int GetValue(int x, int y);
 		public abstract void SetValue(int x, int y, int value);
 
-		public void SetValue(int x, int y, float value)
+		public virtual void SetValue(int x, int y, float value)
 		{
 			SetValue(x, y, (int)value);
 		}
-
-		public MonochromeImage<T> Blurred(float factor)
-		{
-			var smaller = ResizeBitmap(GetBitmap(), (int)(size.Width / factor), (int)(size.Height / factor));
-			var blurred = ResizeBitmap(smaller, size.Width, size.Height);
-			return new MonochromeImage<T>(blurred);
-		}
-
-		private static Bitmap ResizeBitmap(Bitmap bmp, int width, int height)
-		{
-			var result = new Bitmap(width, height);
-			using (Graphics g = Graphics.FromImage(result))
-			{
-				g.DrawImage(bmp, 0, 0, width, height);
-			}
-			return result;
 	}
 }

--- a/Rasterizer/RasterPrinter.cs
+++ b/Rasterizer/RasterPrinter.cs
@@ -30,13 +30,16 @@ namespace Rasterizer
 		/// <param name="rotateForLargerPrint">If true, the image will be rotated 90 degrees if that would increase the printed size.</param>
 		/// <param name="enhancers">Array of image enhancers to use - they will be applied in this order.</param>
 		/// <returns></returns>
-		public byte[] ImageToPrintCommands(Bitmap inputImage, IDitherer ditherer, bool rotateForLargerPrint = true, IEnhancer[] enhancers = {})
+		public byte[] ImageToPrintCommands(Bitmap inputImage, IDitherer ditherer, bool rotateForLargerPrint = true, IEnhancer[] enhancers = null)
 		{
 			var resized = ScaleToFitPage(inputImage, rotateForLargerPrint);
 			var enhanced = new GrayscaleImage(resized);
-			foreach (IEnhancer enhancer in enhancers)
+			if (enhancers != null)
 			{
-				enhanced = enhancer.Enhance(enhanced);
+				foreach (IEnhancer enhancer in enhancers)
+				{
+					enhanced = enhancer.Enhance(enhanced);
+				}
 			}
 			BWImage result = ditherer.GetBWImage(enhanced);
 			byte[] printCommands = RasterToPrintCommands(result);

--- a/Rasterizer/RasterPrinter.cs
+++ b/Rasterizer/RasterPrinter.cs
@@ -32,7 +32,7 @@ namespace Rasterizer
 		public byte[] ImageToPrintCommands(Bitmap inputImage, IDitherer ditherer, bool rotateForLargerPrint = true)
 		{
 			var resized = ScaleToFitPage(inputImage, rotateForLargerPrint);
-			BWImage result = ditherer.GetBWImage(resized);
+			BWImage result = ditherer.GetBWImage(new GrayscaleImage(resized));
 			byte[] printCommands = RasterToPrintCommands(result);
 			return printCommands;
 		}

--- a/Rasterizer/RasterPrinter.cs
+++ b/Rasterizer/RasterPrinter.cs
@@ -28,11 +28,17 @@ namespace Rasterizer
 		/// <param name="inputImage"></param>
 		/// <param name="ditherer">The ditherer to be used. Use new BurkesDitherer() if unsure.</param>
 		/// <param name="rotateForLargerPrint">If true, the image will be rotated 90 degrees if that would increase the printed size.</param>
+		/// <param name="enhancers">Array of image enhancers to use - they will be applied in this order.</param>
 		/// <returns></returns>
-		public byte[] ImageToPrintCommands(Bitmap inputImage, IDitherer ditherer, bool rotateForLargerPrint = true)
+		public byte[] ImageToPrintCommands(Bitmap inputImage, IDitherer ditherer, bool rotateForLargerPrint = true, IEnhancer[] enhancers = {})
 		{
 			var resized = ScaleToFitPage(inputImage, rotateForLargerPrint);
-			BWImage result = ditherer.GetBWImage(new GrayscaleImage(resized));
+			var enhanced = new GrayscaleImage(resized);
+			foreach (IEnhancer enhancer in enhancers)
+			{
+				enhanced = enhancer.Enhance(enhanced);
+			}
+			BWImage result = ditherer.GetBWImage(enhanced);
 			byte[] printCommands = RasterToPrintCommands(result);
 			return printCommands;
 		}

--- a/client/fakeprintimini.sh
+++ b/client/fakeprintimini.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+! mkdir tmp
+cd tmp
+
+while true
+do
+	if (wget --content-disposition --trust-server-names api.printi.me/nextinqueue/$1)
+	then
+		downloadedfile=$(ls)
+
+		extension="${downloadedfile#*.}"
+		newname=$(ls .. | wc -l).bmp
+
+		cat $downloadedfile | ../printiminitoBMP > ../$newname
+
+		rm $downloadedfile
+		(cd ..; /mnt/c/Program\ Files/IrfanView/i_view64.exe "$newname /hide=7 /pos=(0,0)") &
+	fi
+done


### PR DESCRIPTION
`ImageToPrintCommands` now accepts an array of `IEnhancer` - image filters to apply before dithering. I implemented two enhancers:
- `HDREnhancer` - adjusts local brightness to avoid bright areas becoming entirely white (and vice versa for dark ones)
- `ContrastEnhancer` - does what it says on the tin :)
- `QuantileEnhancer` - makes sure that the the distribution of brightness levels is uniform across the image

I'd go for calling `ImageToPrintCommands` with `enhancers = {new QuantileEnhancer(0.5f), new HDREnhancer(0.1f, 8), new ContrastEnhancer(0.25f, 16)}`.

Also! I didn't test this on the device, just made sure that pictures look nice after some enhancements and dithering.